### PR TITLE
Fix compilation on stable channel

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,7 +13,10 @@ keywords = ["leptos", "web", "framework", "reactive", "isomorphic"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-stable = []
+default = ["unboxed_closures", "fn_traits"]
+unboxed_closures = []
+fn_traits = []
+stable = ["leptos/stable"]
 
 [dependencies]
 futures = "0.3"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,10 +13,7 @@ keywords = ["leptos", "web", "framework", "reactive", "isomorphic"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["unboxed_closures", "fn_traits"]
-unboxed_closures = []
-fn_traits = []
-stable = ["leptos/stable"]
+stable = []
 
 [dependencies]
 futures = "0.3"

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -210,11 +210,11 @@ impl<Msg: 'static> Drop for Cmd<Msg> {
         let mut cmds = cmds.await.into_iter();
 
         if let Some(msg) = cmds.next() {
-          msg_dispatcher(msg);
+          msg_dispatcher.set(msg);
         }
 
         for msg in cmds {
-          spawn_local(async move { msg_dispatcher(msg) });
+          spawn_local(async move { msg_dispatcher.set(msg) });
         }
       });
     }


### PR DESCRIPTION
First of all, thank you for your work on `leptos-tea` :slightly_smiling_face: 

Compilation on stable currently fails due to the following errors:

```bash
❯ cargo build -F stable
   Compiling server_fn_macro v0.2.5
   Compiling leptos_reactive v0.2.5
error[E0554]: `#![feature]` may not be used on the stable release channel
 --> /home/denis/.cargo/registry/src/github.com-1ecc6299db9ec823/server_fn_macro-0.2.5/src/lib.rs:1:46
  |
1 | #![cfg_attr(not(feature = "stable"), feature(proc_macro_span))]
  |                                              ^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0554`.
error: could not compile `server_fn_macro` due to previous error
warning: build failed, waiting for other jobs to finish...
error[E0554]: `#![feature]` may not be used on the stable release channel
 --> /home/denis/.cargo/registry/src/github.com-1ecc6299db9ec823/leptos_reactive-0.2.5/src/lib.rs:2:38
  |
2 | #![cfg_attr(not(feature = "stable"), feature(fn_traits))]
  |                                      ^^^^^^^^^^^^^^^^^^

error[E0554]: `#![feature]` may not be used on the stable release channel
 --> /home/denis/.cargo/registry/src/github.com-1ecc6299db9ec823/leptos_reactive-0.2.5/src/lib.rs:3:38
  |
3 | #![cfg_attr(not(feature = "stable"), feature(unboxed_closures))]
  |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0554]: `#![feature]` may not be used on the stable release channel
 --> /home/denis/.cargo/registry/src/github.com-1ecc6299db9ec823/leptos_reactive-0.2.5/src/lib.rs:4:38
  |
4 | #![cfg_attr(not(feature = "stable"), feature(type_name_of_val))]
  |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0554]: `#![feature]` may not be used on the stable release channel
 --> /home/denis/.cargo/registry/src/github.com-1ecc6299db9ec823/leptos_reactive-0.2.5/src/lib.rs:2:46
  |
2 | #![cfg_attr(not(feature = "stable"), feature(fn_traits))]
  |                                              ^^^^^^^^^

error[E0554]: `#![feature]` may not be used on the stable release channel
 --> /home/denis/.cargo/registry/src/github.com-1ecc6299db9ec823/leptos_reactive-0.2.5/src/lib.rs:4:46
  |
4 | #![cfg_attr(not(feature = "stable"), feature(type_name_of_val))]
  |                                              ^^^^^^^^^^^^^^^^

error: could not compile `leptos_reactive` due to 5 previous errors
```

```bash
   Compiling leptos_tea v0.3.0 (/home/denis/Development/gits/leptos-tea/lib)
error[E0618]: expected function, found `leptos::SignalSetter<Msg>`
   --> /home/denis/Development/gits/leptos-tea/lib/src/lib.rs:213:11
    |
206 |     let msg_dispatcher = self.msg_dispatcher;
    |         -------------- `msg_dispatcher` has type `leptos::SignalSetter<Msg>`
...
213 |           msg_dispatcher(msg);
    |           ^^^^^^^^^^^^^^-----
    |           |
    |           call expression requires function

error[E0618]: expected function, found `leptos::SignalSetter<Msg>`
   --> /home/denis/Development/gits/leptos-tea/lib/src/lib.rs:217:36
    |
206 |     let msg_dispatcher = self.msg_dispatcher;
    |         -------------- `msg_dispatcher` has type `leptos::SignalSetter<Msg>`
...
217 |           spawn_local(async move { msg_dispatcher(msg) });
    |                                    ^^^^^^^^^^^^^^-----
    |                                    |
    |                                    call expression requires function

For more information about this error, try `rustc --explain E0618`.
error: could not compile `leptos_tea` due to 2 previous errors
```

This PR should fix it.